### PR TITLE
Update: 画面遷移時に一瞬だけ現れるものたちをちょっといい感じにした

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-11-22T22:25:59.176181800Z" />
+    <timeTargetWasSelectedWithDropDown value="2021-11-23T21:20:57.679090900Z" />
   </component>
 </project>

--- a/app/src/main/java/com/websarva/wings/android/flat/view/FriendsFragment.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/view/FriendsFragment.kt
@@ -32,6 +32,7 @@ class FriendsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        binding.friendsProgress.visibility = View.VISIBLE
         binding.rvFriends.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = FriendsAdapter(viewLifecycleOwner, viewModel).also {
@@ -40,6 +41,7 @@ class FriendsFragment : Fragment() {
         }
 
         viewModel.friends.observe(viewLifecycleOwner, {
+            binding.friendsProgress.visibility = View.GONE
             when {
                 it.mutual.isEmpty() -> {
                     binding.rvFriends.visibility = View.INVISIBLE

--- a/app/src/main/java/com/websarva/wings/android/flat/view/UnapprovedFriendsFragment.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/view/UnapprovedFriendsFragment.kt
@@ -33,6 +33,7 @@ class UnapprovedFriendsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        binding.unapprovedFriendsProgress.visibility = View.VISIBLE
         binding.rvUnapprovedFriends.apply {
             layoutManager = LinearLayoutManager(context)
             adapter =
@@ -42,12 +43,15 @@ class UnapprovedFriendsFragment : Fragment() {
         }
 
         viewModel.friends.observe(viewLifecycleOwner, {
+            binding.unapprovedFriendsProgress.visibility = View.GONE
             when {
                 it.one_side.isEmpty() -> {
+                    binding.rvUnapprovedFriends.visibility = View.INVISIBLE
                     binding.tvNoUnapprovedFriend.visibility = View.VISIBLE
                 }
                 else -> {
                     binding.tvNoUnapprovedFriend.visibility = View.GONE
+                    binding.rvUnapprovedFriends.visibility = View.VISIBLE
                 }
             }
             unapprovedFriendsAdapter.submitList(it.one_side)

--- a/app/src/main/java/com/websarva/wings/android/flat/viewmodel/FriendListViewModel.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/viewmodel/FriendListViewModel.kt
@@ -23,10 +23,10 @@ class FriendListViewModel(
     val friendsCount: MediatorLiveData<MutableMap<String, Int>> =
         MediatorLiveData<MutableMap<String, Int>>()
 
-    private val _friends = MutableLiveData<ResponseData.ResponseGetFriends>()
+    private val _friends = LiveEvent<ResponseData.ResponseGetFriends>()
     val friends: LiveData<ResponseData.ResponseGetFriends> get() = _friends
 
-    private val _getFriendsCode = MutableLiveData<Int>()
+    private val _getFriendsCode = LiveEvent<Int>()
     val getFriendsCode: LiveData<Int> get() = _getFriendsCode
 
     private val _postApproveFriendCode = MutableLiveData<Int>()

--- a/app/src/main/res/anim/nav_zoom_enter_anim.xml
+++ b/app/src/main/res/anim/nav_zoom_enter_anim.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale
+        android:duration="@integer/config_navAnimTime"
+        android:fromXScale="0.9"
+        android:fromYScale="0.9"
+        android:interpolator="@android:anim/decelerate_interpolator"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="1"
+        android:toYScale="1" />
+    <alpha
+        android:duration="@integer/config_navAnimTime"
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+</set>

--- a/app/src/main/res/layout/fragment_friends.xml
+++ b/app/src/main/res/layout/fragment_friends.xml
@@ -8,6 +8,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_friends"
+        android:visibility="invisible"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
@@ -48,5 +49,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_some_unapproved_friends" />
+
+    <ProgressBar
+        android:id="@+id/friends_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_unapproved_friends.xml
+++ b/app/src/main/res/layout/fragment_unapproved_friends.xml
@@ -26,4 +26,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ProgressBar
+        android:id="@+id/unapproved_friends_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -19,6 +19,7 @@
         tools:layout="@layout/fragment_friend_list" >
         <action
             android:id="@+id/action_friendListFragment_to_addFriendFragment"
+            app:enterAnim="@anim/nav_zoom_enter_anim"
             app:destination="@id/addFriendFragment" />
     </fragment>
     <fragment


### PR DESCRIPTION
Fix #41 
Closes #29 

検索画面から友だち一覧画面に遷移するときや、初回未承認にスワイプするときの画面などをちょっとだけ良い感じにしました。

ツールバーがあるところと無いところでの画面遷移で一瞬画面が乱れてしまうのは、ツールバーの有無によってFragmentをAttachしている部分の広さが変わるのと、ツールバーの表示非表示とフラグメントの入れ替えが別々に動いていることが原因だと思われるので、後々ツールバーの操作をMainActivityからそれぞれのFragmentに変える方法を調べてやります。