### PR TITLE
fix: Android 12からPendingIntentにFLAG_IMMUTABLEの指定が必要

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/flat/BeaconDetectionService.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/BeaconDetectionService.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import org.altbeacon.beacon.*
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
 import com.hadilq.liveevent.LiveEvent
@@ -128,7 +129,7 @@ class BeaconDetectionService : Service(), RangeNotifier, MonitorNotifier {
         val notifyIntent = Intent(this, MainActivity::class.java).apply {
             this.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
-        val pendingIntent: PendingIntent =  PendingIntent.getActivity(this, 0, notifyIntent, 0)
+        val pendingIntent: PendingIntent =  PendingIntent.getActivity(this, 0, notifyIntent, FLAG_IMMUTABLE)
 
         val notification: Notification = NotificationCompat.Builder(this, channelId)
             .setContentTitle("FLAT Service")


### PR DESCRIPTION
エラー文より
> Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.

Android環境作り直して起動したら怒られてクラッシュ
…これまでは怒られてなかった謎

```
2022-09-02 09:06:37.604 9178-9178/com.websarva.wings.android.flat E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.websarva.wings.android.flat, PID: 9178
    java.lang.RuntimeException: Unable to start service com.websarva.wings.android.flat.BeaconDetectionService@414510d with Intent { cmp=com.websarva.wings.android.flat/.BeaconDetectionService }: java.lang.IllegalArgumentException: com.websarva.wings.android.flat: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:4657)
        at android.app.ActivityThread.access$2000(ActivityThread.java:247)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2091)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: java.lang.IllegalArgumentException: com.websarva.wings.android.flat: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:458)
        at android.app.PendingIntent.getActivity(PendingIntent.java:444)
        at android.app.PendingIntent.getActivity(PendingIntent.java:408)
        at com.websarva.wings.android.flat.BeaconDetectionService.onStartCommand(BeaconDetectionService.kt:131)
        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:4639)
        	... 9 more
```