### PR TITLE
Add: ビーコン毎にRSSIの平均をとって最大のやつを返すやつ

### DIFF
--- a/app/src/main/java/com/websarva/wings/android/flat/BeaconDetectionService.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/BeaconDetectionService.kt
@@ -52,6 +52,7 @@ class BeaconDetectionService : Service(), RangeNotifier, MonitorNotifier {
         }
         // TODO:IDをroom等で内部に保存しrepositoryから持ってくる
         if (nearBeacon != null) {
+            //rssiの値をサーバーに送信しているが、使用はされていない
             postData = PostData.PostBeacon(
                 user_id = myId,
                 major = nearBeacon.id2.toInt(),

--- a/app/src/main/java/com/websarva/wings/android/flat/api/PostData.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/api/PostData.kt
@@ -9,6 +9,7 @@ class PostData {
     )
 
     data class PostBeacon(
+        //rssiの値をサーバーに送信しているが、使用はされていない
         @Json(name = "user_id") val user_id: Int,
         @Json(name = "major") val major: Int,
         @Json(name = "minor") val minor: Int,

--- a/app/src/main/java/com/websarva/wings/android/flat/other/BeaconQueueExtention.kt
+++ b/app/src/main/java/com/websarva/wings/android/flat/other/BeaconQueueExtention.kt
@@ -1,0 +1,44 @@
+package com.websarva.wings.android.flat.other
+
+import org.altbeacon.beacon.Beacon
+import java.util.Queue
+
+private data class BeaconIdentifier(val major: Int, val minor: Int)
+
+// Queue内のBeaconの中からもっともRSSIの平均値が大きいものを選ぶ
+// さらにその中で最もRSSIの値が大きいBeaconを返す
+// Queueが空ならnullを返す
+fun Queue<Beacon>.averageMaxRssi(): Beacon? {
+    if (this.size == 0) return null
+
+    val beaconRssiSum: MutableMap<BeaconIdentifier, Int> = mutableMapOf()
+    val beaconCounter: MutableMap<BeaconIdentifier, Int> = mutableMapOf()
+
+    this.forEach {x ->
+        val identifier = BeaconIdentifier(x.id2.toInt(), x.id3.toInt())
+
+        if (!beaconRssiSum.contains(identifier)) {
+            beaconRssiSum[identifier] = x.rssi
+            beaconCounter[identifier] = 1
+        }
+        else {
+            beaconRssiSum[identifier] = beaconRssiSum[identifier]!! + x.rssi
+            beaconCounter[identifier] = beaconCounter[identifier]!! + 1
+        }
+    }
+
+    var currentMaxAverage = 0.0
+    var resIdentifier = BeaconIdentifier(0, 0)
+
+    beaconRssiSum.forEach { (k, v) ->
+        val averageRssi = v.toDouble() / beaconCounter[k]!!.toDouble()
+        if (currentMaxAverage < averageRssi) {
+            currentMaxAverage = averageRssi
+            resIdentifier = k
+        }
+    }
+
+    return this
+        .filter { BeaconIdentifier(it.id2.toInt(), it.id3.toInt()) == resIdentifier }
+        .maxBy { it.rssi }
+}

--- a/app/src/test/java/com/websarva/wings/android/flat/other/BeaconQueueExtentionKtTest.kt
+++ b/app/src/test/java/com/websarva/wings/android/flat/other/BeaconQueueExtentionKtTest.kt
@@ -1,0 +1,123 @@
+package com.websarva.wings.android.flat.other
+
+import org.altbeacon.beacon.Beacon
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.Queue
+import java.util.ArrayDeque
+
+// テストを書くときに、
+// Kotlin.collections.ArrayDequeではなく、java.util.ArrayDequeを使って空のQueueを作る
+
+class BeaconQueueExtentionKtTest {
+    @Test
+    fun BeaconQueueExtentionTest1() {
+        //同じBeaconが複数あるとき、そのうちRSSIが最大なBeaconを返す
+        val beaconData: List<Beacon> = listOf(
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(10).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(30).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(20).build()
+        )
+        val a: Queue<Beacon> = ArrayDeque()
+        beaconData.forEach { a.add(it) }
+
+        assertEquals(a.averageMaxRssi(), beaconData[1])
+    }
+
+    @Test
+    fun BeaconQueueExtentionTest2() {
+        //同じBeaconが複数あるとき、そのうちRSSIが最大なBeaconを返す
+        val beaconData: List<Beacon> = listOf(
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(10).build(),
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(20).build()
+        )
+        val a: Queue<Beacon> = ArrayDeque()
+        beaconData.forEach { a.add(it) }
+
+        assertEquals(a.averageMaxRssi(), beaconData[1])
+    }
+
+    @Test
+    fun BeaconQueueExtentionTest3() {
+        //RSSIの平均値が最大なBeaconを返す
+        //ただし、平均が最大なBeaconの中でも最もRSSIが大きな値のものを返す
+        val beaconData: List<Beacon> = listOf(
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(10).build(),
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(15).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(15).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(20).build()
+        )
+        val a: Queue<Beacon> = ArrayDeque()
+        beaconData.forEach { a.add(it) }
+
+        assertEquals(a.averageMaxRssi(), beaconData[3])
+    }
+
+    @Test
+    fun BeaconQueueExtentionTest4() {
+        //自明なケース (それしかないならそれ)
+        val beacon = Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(60).build()
+        val a: Queue<Beacon> = ArrayDeque()
+        a.add(beacon)
+
+        assertEquals(a.averageMaxRssi(), beacon)
+    }
+
+    @Test
+    fun BeaconQueueExtentionTest5() {
+        //自明なケース (空ならnull)
+        val a: Queue<Beacon> = ArrayDeque()
+        assertEquals(a.averageMaxRssi(), null)
+    }
+
+    @Test
+    fun BeaconQueueExtentionTest6() {
+        // 大きめのケース; Queue<Beacon>.size == 30
+        val beaconData: List<Beacon> = listOf(
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(35).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(58).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(40).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(20).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(57).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(51).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(26).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(51).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(27).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(50).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(45).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(35).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(34).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(47).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(40).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(39).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(47).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(33).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(47).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(42).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(54).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(45).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(60).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(37).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(47).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(21).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(60).build(),
+
+            Beacon.Builder().setId1("aaa").setId2("1").setId3("10").setRssi(34).build(),
+            Beacon.Builder().setId1("bbb").setId2("2").setId3("20").setRssi(42).build(),
+            Beacon.Builder().setId1("ccc").setId2("3").setId3("30").setRssi(56).build(),
+        )
+
+        val a: Queue<Beacon> = ArrayDeque()
+        beaconData.forEach { a.add(it) }
+
+        assertEquals(a.averageMaxRssi(), beaconData[22])
+    }
+}


### PR DESCRIPTION
- ファイル: [BeaconQueueExtention.kt](app/src/main/java/com/websarva/wings/android/flat/other/BeaconQueueExtention.kt)を追加
- ファイル: [BeaconQueueExtentionKtTest.kt](https://github.com/FLAT-ICT/FLAT-Android/compare/develop...Yourein:FLAT-Android:feature/map_RSSI_to_Beacon?expand=1#diff-7d93c54a8d68ae7e1f5308b20f5f997c08e6b6773a3239fae7f0656e59df42cf)を追加

# Queue\<Beacon\>.averageMaxRssi() -> Beacon?

- Queue\<Beacon\>に含まれるIdが相異なるBeacon毎にRSSIの総和を取り、平均を求める (Queueが空ならnull)
- 平均RSSIが最も大きなBeaconを返す
- 同じIdを持つBeaconが複数ある ( ↔ 同じBeaconから受け取ったデータが複数ある ) 場合、その中で最もRSSIが大きなBeacon ( ↔ 当該Beaconから受け取ったデータの中で最もRSSIの値が大きかったデータ ) が返される